### PR TITLE
Send `503` instead of `303` for `curl -i localhost:2002/path-with-unknown-hash`

### DIFF
--- a/TKN/Praxis_2/rn-praxis/DHT.c
+++ b/TKN/Praxis_2/rn-praxis/DHT.c
@@ -9,12 +9,14 @@
 
 #include "DHT.h"
 
+// Simple Sha256 hash function
 uint16_t hash(const char *str) {
   uint8_t digest[SHA256_DIGEST_LENGTH];
   SHA256((uint8_t *)str, strlen(str), digest);
   return htons(*((uint32_t *)digest));
 }
 
+// Check if the given hash lies within responsibility of the two IDs
 bool is_responsible(uint32_t current_id, uint32_t successor_id, uint32_t hash) {
   if (current_id > successor_id) {
     return hash < current_id && hash > successor_id;
@@ -23,6 +25,7 @@ bool is_responsible(uint32_t current_id, uint32_t successor_id, uint32_t hash) {
   }
 }
 
+// Send `LoopupMessage` to destination using socket.
 int send_message(struct LookupMessage *message, struct Destination destination,
                  int sockfd) {
   struct sockaddr_in nodeAddr;
@@ -49,6 +52,8 @@ int send_message(struct LookupMessage *message, struct Destination destination,
   return 0;
 }
 
+// Similar to send_message, it sends a `LookupMessage` to destination using socket,
+// however it waits for a reply from destination and closes the socket upon successful reply.
 int send_lookup(struct LookupMessage *message, struct Destination destination,
                 int sockfd) {
   struct LookupMessage reply;
@@ -95,6 +100,9 @@ int send_lookup(struct LookupMessage *message, struct Destination destination,
   return -1;
 }
 
+// Counterpart to `send_lookup`, receive `LookupMessage` and determine whether
+// or not this node needs to handle the message based on the hash and its ID.
+// It sends a reply message if it is responsible.
 int receive_lookup(struct LookupMessage *message, DHT_NODE *node, int sockfd) {
   struct Destination destination;
 

--- a/TKN/Praxis_2/rn-praxis/data.h
+++ b/TKN/Praxis_2/rn-praxis/data.h
@@ -5,6 +5,10 @@
 
 #include "util.h"
 
+/*
+ * This more or less just defines a dict, a rather inefficient dict
+ */
+
 /**
  * A simple key-value entry
  *

--- a/TKN/Praxis_2/rn-praxis/http.h
+++ b/TKN/Praxis_2/rn-praxis/http.h
@@ -7,6 +7,10 @@
 #define HTTP_MAX_SIZE 8192
 #define HTTP_MAX_HEADERS 40
 
+/*
+ * Helper functions for handling HTTP requests
+ */
+
 /**
  * Simple string tuple representing a HTTP header
  */

--- a/TKN/Praxis_2/rn-praxis/util.h
+++ b/TKN/Praxis_2/rn-praxis/util.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+/*
+ * Helper functions for handling strings (finding substrings and converting ints in strings to actual ints)
+ */
+
 typedef char *string; // differentiate null-terminated C-string from bytes
 
 /**

--- a/TKN/Praxis_2/rn-praxis/webserver.c
+++ b/TKN/Praxis_2/rn-praxis/webserver.c
@@ -32,6 +32,7 @@ struct tuple resources[MAX_RESOURCES] = {
     {"/static/bar", "Bar", sizeof "Bar" - 1},
     {"/static/baz", "Baz", sizeof "Baz" - 1}};
 
+// Initialize fields in given node based on console environment variables.
 void initialize_node(DHT_NODE *node) {
   // Read predecessor info from evnironment variables
   node->predecessor.id = atoi(getenv("PRED_ID"));
@@ -354,7 +355,7 @@ void parse_arguments(int argc, char *argv[], DHT_NODE *node) {
 }
 
 /**
- *  The program expects 5; otherwise, it returns EXIT_FAILURE.
+ *  The program expects 5 args; otherwise, it returns EXIT_FAILURE.
  *
  *  Call as:
  *

--- a/TKN/Praxis_2/rn-praxis/webserver.c
+++ b/TKN/Praxis_2/rn-praxis/webserver.c
@@ -117,9 +117,9 @@ void send_reply(int conn, struct request *request, DHT_NODE *node) {
           get(request->uri, resources, MAX_RESOURCES, &resource_length);
 
       sprintf(reply,
-              "HTTP/1.1 303 See "
-              "Other\r\nLocation:http://%s:%d%s\r\nContent-Length: %lu\r\n\r\n",
-              ip_str, message.node_port, request->uri, resource_length);
+              "HTTP/1.1 503 Service Unavailable\r\n"
+              "Retry-after: 1\r\n"
+              "Content-length: 0\r\n");
     }
   }
 


### PR DESCRIPTION
You probably don't want to merge this, I just created the PR because it's easier to share code this way.

I am not quite sure why it was `303` before, the curl should give us `503`, I don't think that changes in later tasks (I am looking at task 3 right now). The pytests are giving me the error

```
>           assert response.status == 503, "Server should reply with 503"
E           AssertionError: Server should reply with 503
E           assert 404 == 503
E            +  where 404 = <http.client.HTTPResponse object at 0x7fc34a431240>.status
```

which I thought would be fixed with this (though in hindsight it actually makes no sense that this change would have fixed anything).